### PR TITLE
Ensure Pathname is present

### DIFF
--- a/lib/procsd/generator.rb
+++ b/lib/procsd/generator.rb
@@ -1,3 +1,5 @@
+require "pathname"
+
 module Procsd
   class Generator
     attr_reader :app_name, :target_name


### PR DESCRIPTION
Without this running `procsd create` results in something like:

    root@1fe086c29ccc:/usr/src/app# procsd create
    Value of the --dir option: /usr/src/app
    Value of the --path option: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
    Creating app units files in the systemd directory (/etc/systemd/system)...
    /usr/local/bundle/gems/procsd-0.5.0/lib/procsd/generator.rb:116:in `exist?': no implicit conversion of nil into String (TypeError)
      from /usr/local/bundle/gems/procsd-0.5.0/lib/procsd/generator.rb:116:in `write_file!'
      from /usr/local/bundle/gems/procsd-0.5.0/lib/procsd/generator.rb:33:in `block (2 levels) in generate_units'
      from /usr/local/bundle/gems/procsd-0.5.0/lib/procsd/generator.rb:30:in `times'
      from /usr/local/bundle/gems/procsd-0.5.0/lib/procsd/generator.rb:30:in `block in generate_units'
      from /usr/local/bundle/gems/procsd-0.5.0/lib/procsd/generator.rb:29:in `each'
      from /usr/local/bundle/gems/procsd-0.5.0/lib/procsd/generator.rb:29:in `generate_units'
      from /usr/local/bundle/gems/procsd-0.5.0/lib/procsd/cli.rb:239:in `perform_create'
      from /usr/local/bundle/gems/procsd-0.5.0/lib/procsd/cli.rb:33:in `create'
      from /usr/local/bundle/gems/thor-0.20.3/lib/thor/command.rb:27:in `run'
      from /usr/local/bundle/gems/thor-0.20.3/lib/thor/invocation.rb:126:in `invoke_command'
      from /usr/local/bundle/gems/thor-0.20.3/lib/thor.rb:387:in `dispatch'
      from /usr/local/bundle/gems/thor-0.20.3/lib/thor/base.rb:466:in `start'
      from /usr/local/bundle/gems/procsd-0.5.0/exe/procsd:6:in `<top (required)>'
      from /usr/local/bundle/bin/procsd:23:in `load'
      from /usr/local/bundle/bin/procsd:23:in `<main>'

which is caused by `temp_path #=> nil`, which in turn is caused by an exception being thrown on

    temp_path = File.join("/tmp", Pathname.new(dest_path).basename.to_s)

The exception that is raised and subsequently silently swallowed since there is an `ensure` clause but no `rescue` is:

    NameError: uninitialized constant Procsd::Generator::Pathname

The pathname library needs to be required for access to the Pathname class.