### PR TITLE
Modernize gem to run on modern versions of ruby and bundler and etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Can we have something similar on the cheap Ubuntu VPS from DigitalOcean? Yes we 
 
 > **Note:** Procsd works best with Capistrano integration: [vifreefly/capistrano-procsd](https://github.com/vifreefly/capistrano-procsd)
 
-Install `procsd` first: `$ gem install procsd`. Required Ruby version is `>= 2.3.0`.
+Install `procsd` first: `$ gem install procsd`. Required Ruby version is `>= 3.2.0`.
 
 Let's say you have following application's Procfile:
 

--- a/lib/procsd/cli.rb
+++ b/lib/procsd/cli.rb
@@ -420,7 +420,7 @@ module Procsd
 
       raise ConfigurationError, "Config file procsd.yml doesn't exists" unless File.exist? "procsd.yml"
       begin
-        procsd = YAML.load(ERB.new(File.read "procsd.yml").result)
+        procsd = YAML.safe_load(ERB.new(File.read "procsd.yml").result)
       rescue => e
         raise ConfigurationError, "Can't read procsd.yml: #{e.inspect}"
       end
@@ -433,7 +433,7 @@ module Procsd
         msg = "Procfile doesn't exists. Define processes in procsd.yml or create Procfile"
         raise ConfigurationError, msg unless File.exist? "Procfile"
         begin
-          procfile = YAML.load_file("Procfile")
+          procfile = YAML.safe_load_file("Procfile")
         rescue => e
           raise ConfigurationError, "Can't read Procfile: #{e.inspect}"
         end

--- a/lib/procsd/generator.rb
+++ b/lib/procsd/generator.rb
@@ -99,7 +99,7 @@ module Procsd
       b.local_variable_set(:config, conf)
       template_path = File.join(File.dirname(__FILE__), "templates/#{template_name}.erb")
       content = File.read(template_path)
-      ERB.new(content, nil, "-").result(b)
+      ERB.new(content, trim_mode: "-").result(b)
     end
 
     def write_file!(dest_path, content)

--- a/procsd.gemspec
+++ b/procsd.gemspec
@@ -22,12 +22,12 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = "procsd"
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = ">= 2.3.0"
+  spec.required_ruby_version = ">= 3.2.0"
 
   spec.add_dependency "thor"
   spec.add_dependency "dotenv"
 
-  spec.add_development_dependency "bundler", "~> 1.16"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler", ">= 1.16"
+  spec.add_development_dependency "rake", ">= 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
 end


### PR DESCRIPTION
Hello, @vifreefly ! I'm hitting limits of how far I can push Foreman and systemd with my own https://github.com/botandrose/foreman-export-systemd_user gem, so I'm looking into using procsd as an alternative, as it looks like a better fit.

Looks like this gem hasn't seen any activity in the last five years, but maybe you're still accepting contributions. If so, here's my first PR to get things running in 2026.

Details:
- Require Ruby >= 3.2.0 (dropping support for EOL versions)
- Use YAML.safe_load instead of deprecated YAML.load
- Use new `trim_mode` keyword argument for ERB.new
- Relax bundler/rake version constraints to allow modern versions